### PR TITLE
Window covering now support position and tilt position in %

### DIFF
--- a/app.json
+++ b/app.json
@@ -3265,7 +3265,9 @@
       },
       "class": "windowcoverings",
       "capabilities": [
-        "windowcoverings_state"
+        "windowcoverings_state",
+        "windowcoverings_set",
+        "windowcoverings_tilt_set"
       ],
       "settings": [
         {
@@ -3382,6 +3384,32 @@
                 "pl": "Wpisz adres grupowy",
                 "ru": "Введите групповой адрес",
                 "ko": "그룹 주소를 입력하세요"
+              }
+            },
+            {
+              "id": "ga_store_position",
+              "type": "text",
+              "label": {
+                "en": "Position address",
+                "fr": "Adresse position store"
+              },
+              "value": "4/3/x",
+              "hint": {
+                "en": "Enter groupaddress",
+                "fr": "Entrez l'adresse de groupe"
+              }
+            },
+            {
+              "id": "ga_slat_position",
+              "type": "text",
+              "label": {
+                "en": "Slat position address",
+                "fr": "Adresse position lamelle"
+              },
+              "value": "4/3/x",
+              "hint": {
+                "en": "Enter groupaddress",
+                "fr": "Entrez l'adresse de groupe"
               }
             }
           ]

--- a/app.json
+++ b/app.json
@@ -3393,7 +3393,7 @@
                 "en": "Position address",
                 "fr": "Adresse position store"
               },
-              "value": "4/3/x",
+              "value": "x/x/x",
               "hint": {
                 "en": "Enter groupaddress",
                 "fr": "Entrez l'adresse de groupe"
@@ -3406,7 +3406,7 @@
                 "en": "Slat position address",
                 "fr": "Adresse position lamelle"
               },
-              "value": "4/3/x",
+              "value": "x/x/x",
               "hint": {
                 "en": "Enter groupaddress",
                 "fr": "Entrez l'adresse de groupe"

--- a/drivers/knx_windowcoverings/device.js
+++ b/drivers/knx_windowcoverings/device.js
@@ -5,90 +5,118 @@ const DatapointTypeParser = require('../../lib/DatapointTypeParser');
 
 class KNXWindowCovering extends KNXGenericDevice {
 
-  onInit() {
-    super.onInit();
-    this.registerCapabilityListener('windowcoverings_state', this.onCapabilityWindowCovering.bind(this));
-  }
+    onInit() {
+        super.onInit();
+        this.registerCapabilityListener('windowcoverings_state', this.onCapabilityWindowCovering.bind(this));
+        this.registerCapabilityListener('windowcoverings_set', this.onCapabilityWindowCoveringSet.bind(this));
+        this.registerCapabilityListener('windowcoverings_tilt_set', this.onCapabilityWindowCoveringTiltSet.bind(this));
+    }
 
-  onKNXEvent(groupaddress, data) {
-    super.onKNXEvent(groupaddress, data);
-    if (groupaddress === this.settings.ga_status) {
-      const state = DatapointTypeParser.onoff(data);
-      if (state) {
-        if (this.settings.invert_updown === true) {
-          this.setCapabilityValue('windowcoverings_state', 'up')
-            .catch((knxerror) => {
-              this.log('Set windowcoverings_state error', knxerror);
-            });
-        } else {
-          this.setCapabilityValue('windowcoverings_state', 'down')
-            .catch((knxerror) => {
-              this.log('Set windowcoverings_state error', knxerror);
-            });
+    onKNXEvent(groupaddress, data) {
+        super.onKNXEvent(groupaddress, data);
+        if (groupaddress === this.settings.ga_status) {
+            const state = DatapointTypeParser.onoff(data);
+            if (state) {
+                if (this.settings.invert_updown === true) {
+                    this.setCapabilityValue('windowcoverings_state', 'up')
+                        .catch((knxerror) => {
+                            this.log('Set windowcoverings_state error', knxerror);
+                        });
+                } else {
+                    this.setCapabilityValue('windowcoverings_state', 'down')
+                        .catch((knxerror) => {
+                            this.log('Set windowcoverings_state error', knxerror);
+                        });
+                }
+            } else if (this.settings.invert_updown === true) {
+                this.setCapabilityValue('windowcoverings_state', 'down')
+                    .catch((knxerror) => {
+                        this.log('Set windowcoverings_state error', knxerror);
+                    });
+            } else {
+                this.setCapabilityValue('windowcoverings_state', 'up')
+                    .catch((knxerror) => {
+                        this.log('Set windowcoverings_state error', knxerror);
+                    });
+            }
+            this.log(state);
         }
-      } else if (this.settings.invert_updown === true) {
-        this.setCapabilityValue('windowcoverings_state', 'down')
-          .catch((knxerror) => {
-            this.log('Set windowcoverings_state error', knxerror);
-          });
-      } else {
-        this.setCapabilityValue('windowcoverings_state', 'up')
-          .catch((knxerror) => {
-            this.log('Set windowcoverings_state error', knxerror);
-          });
-      }
-      this.log(state);
     }
-  }
 
-  onCapabilityWindowCovering(value, opts) {
-    this.log(value);
-    if (this.knxInterface) {
-      switch (value) {
-        case 'up':
-          if (this.settings.ga_stop) {
-            this.knxInterface.writeKNXGroupAddress(this.settings.ga_stop, 0, 'DPT1');
-          }
+    onCapabilityWindowCovering(value, opts) {
+        this.log(value);
+        if (this.knxInterface) {
+            switch (value) {
+                case 'up':
+                    if (this.settings.ga_stop) {
+                        this.knxInterface.writeKNXGroupAddress(this.settings.ga_stop, 0, 'DPT1');
+                    }
 
-          if (this.settings.invert_updown === true) {
-            return this.knxInterface.writeKNXGroupAddress(this.settings.ga_up_down, 1, 'DPT1')
-              .catch((knxerror) => {
-                throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
-              });
-          }
-          return this.knxInterface.writeKNXGroupAddress(this.settings.ga_up_down, 0, 'DPT1')
-            .catch((knxerror) => {
-              throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
-            });
-        case 'down':
-          if (this.settings.ga_stop) {
-            this.knxInterface.writeKNXGroupAddress(this.settings.ga_stop, 0, 'DPT1');
-          }
-          if (this.settings.invert_updown === true) {
-            return this.knxInterface.writeKNXGroupAddress(this.settings.ga_up_down, 0, 'DPT1')
-              .catch((knxerror) => {
-                throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
-              });
-          }
-          return this.knxInterface.writeKNXGroupAddress(this.settings.ga_up_down, 1, 'DPT1')
-            .catch((knxerror) => {
-              throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
-            });
-        case 'idle':
-          this.log('stop selected, stop address', this.settings.ga_stop);
-          if (this.settings.ga_stop) {
-            return this.knxInterface.writeKNXGroupAddress(this.settings.ga_stop, 1, 'DPT1')
-              .catch((knxerror) => {
-                throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
-              });
-          }
-          break;
-        default:
-          throw new Error(this.homey.__('errors.windowcovering_failed'));
-      }
+                    if (this.settings.invert_updown === true) {
+                        return this.knxInterface.writeKNXGroupAddress(this.settings.ga_up_down, 1, 'DPT1')
+                            .catch((knxerror) => {
+                                throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
+                            });
+                    }
+                    return this.knxInterface.writeKNXGroupAddress(this.settings.ga_up_down, 0, 'DPT1')
+                        .catch((knxerror) => {
+                            throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
+                        });
+                case 'down':
+                    if (this.settings.ga_stop) {
+                        this.knxInterface.writeKNXGroupAddress(this.settings.ga_stop, 0, 'DPT1');
+                    }
+                    if (this.settings.invert_updown === true) {
+                        return this.knxInterface.writeKNXGroupAddress(this.settings.ga_up_down, 0, 'DPT1')
+                            .catch((knxerror) => {
+                                throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
+                            });
+                    }
+                    return this.knxInterface.writeKNXGroupAddress(this.settings.ga_up_down, 1, 'DPT1')
+                        .catch((knxerror) => {
+                            throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
+                        });
+                case 'idle':
+                    this.log('stop selected, stop address', this.settings.ga_stop);
+                    if (this.settings.ga_stop) {
+                        return this.knxInterface.writeKNXGroupAddress(this.settings.ga_stop, 1, 'DPT1')
+                            .catch((knxerror) => {
+                                throw new Error(this.homey.__('errors.windowcovering_failed'), knxerror);
+                            });
+                    }
+                    break;
+                default:
+                    throw new Error(this.homey.__('errors.windowcovering_failed'));
+            }
+        }
+        return null;
     }
-    return null;
-  }
+
+    onCapabilityWindowCoveringSet(value, opts) {
+        if (this.knxInterface && this.settings.ga_store_position) {
+            const storePosition = this.settings.invert_updown === true
+                ? 255 - value * 255 : value * 255;
+            return this.knxInterface.writeKNXGroupAddress(this.settings.ga_store_position, storePosition, 'DPT5')
+                .catch((knxerror) => {
+                    this.log(knxerror);
+                    throw new Error(this.homey.__('errors.windowcoverings_set_failed'));
+                });
+        }
+        return null;
+    }
+
+    onCapabilityWindowCoveringTiltSet(value, opts) {
+        if (this.knxInterface && this.settings.ga_slat_position) {
+            const slatPosition = this.settings.invert_updown === true
+                ? 255 - value * 255 : value * 255;
+            return this.knxInterface.writeKNXGroupAddress(this.settings.ga_slat_position, slatPosition, 'DPT5')
+                .catch((knxerror) => {
+                    this.log(knxerror);
+                    throw new Error(this.homey.__('errors.windowcoverings_tilt_set_failed'));
+                });
+        }
+        return null;
+    }
 
 }
 

--- a/drivers/knx_windowcoverings/driver.compose.json
+++ b/drivers/knx_windowcoverings/driver.compose.json
@@ -19,7 +19,9 @@
   },
   "class": "windowcoverings",
   "capabilities": [
-    "windowcoverings_state"
+    "windowcoverings_state",
+    "windowcoverings_set",
+    "windowcoverings_tilt_set"
   ],
   "pair": [
     {
@@ -163,6 +165,32 @@
             "pl": "Wpisz adres grupowy",
             "ru": "Введите групповой адрес",
             "ko": "그룹 주소를 입력하세요"
+          }
+        },
+        {
+          "id": "ga_store_position",
+          "type": "text",
+          "label": {
+            "en": "Position address",
+            "fr": "Adresse position store"
+          },
+          "value": "x/x/x",
+          "hint": {
+            "en": "Enter groupaddress",
+            "fr": "Entrez l'adresse de groupe"
+          }
+        },
+        {
+          "id": "ga_slat_position",
+          "type": "text",
+          "label": {
+            "en": "Slat position address",
+            "fr": "Adresse position lamelle"
+          },
+          "value": "x/x/x",
+          "hint": {
+            "en": "Enter groupaddress",
+            "fr": "Entrez l'adresse de groupe"
           }
         }
       ]

--- a/lib/DatapointTypeParser.js
+++ b/lib/DatapointTypeParser.js
@@ -19,6 +19,13 @@ class DatapointTypeParser {
     return (buffer.readUInt8(0) / 255);
   }
 
+  // DPT 5.001
+  static percentage(buffer, defaultValue = 0) {
+    if (buffer.length < 1) return defaultValue;
+    const byte1 = buffer.readUInt8(0);
+    return parseFloat((byte1 / 2.55).toFixed(2));
+  }
+
   static colorChannel(buffer, defaultValue = 0) {
     if (buffer.length < 1) return defaultValue;
     return buffer.readUInt8(0);

--- a/lib/DatapointTypeParser.js
+++ b/lib/DatapointTypeParser.js
@@ -37,19 +37,13 @@ class DatapointTypeParser {
   }
 
   static dpt14(buffer) {
-    if (!buffer
-      && !buffer.length === 4
-      && !typeof buffer === 'buffer'
-    ) {
-      return new Error('invalid dpt14 data');
-    }
-
+    if (!buffer && !buffer.length === 4 && !typeof buffer === 'buffer') return new Error('invalid dpt14 data');
     return buffer.readFloatBE(0);
   }
 
   static dpt17(buffer) {
     if (buffer.length < 1) return 0;
-    return buffer.readUInt8(0);
+    return buffer.readUInt8(0) & 0x3F;
   }
 
   // Helper function for float calculations, copied form the knx library dpt9.js file.

--- a/lib/GenericKNXDevice.js
+++ b/lib/GenericKNXDevice.js
@@ -110,19 +110,22 @@ class GenericKNXDevice extends Homey.Device {
       if (typeof settings.ga_status === 'string' && settings.ga_status !== '') {
         statusAddress = settings.ga_status;
       }
-
       this.knxInterface.addKNXEventListener(statusAddress, this.KNXEventHandler);
     }
+
     if (this.hasCapability('scene_capability')) {
       this.knxInterface.addKNXEventListener(settings.ga_scene, this.KNXEventHandler);
     }
+
     if (this.hasCapability('dim')) {
       this.knxInterface.addKNXEventListener(settings.ga_dim_status, this.KNXEventHandler);
     }
+
     if (this.hasCapability('target_temperature')) {
       this.knxInterface.addKNXEventListener(settings.ga_temperature_target,
         this.KNXEventHandler);
     }
+
     if (this.hasCapability('measure_temperature')) {
       if (this.settings.ga_sensor) {
         this.knxInterface.addKNXEventListener(settings.ga_sensor, this.KNXEventHandler);
@@ -131,12 +134,19 @@ class GenericKNXDevice extends Homey.Device {
           this.KNXEventHandler);
       }
     }
+
+    if (this.hasCapability('measure_power')) {
+      this.knxInterface.addKNXEventListener(settings.ga_sensor, this.KNXEventHandler);
+    }
+
     if (this.hasCapability('alarm_contact')) {
       this.knxInterface.addKNXEventListener(settings.ga_sensor, this.KNXEventHandler);
     }
+
     if (this.hasCapability('measure_luminance')) {
       this.knxInterface.addKNXEventListener(settings.ga_sensor, this.KNXEventHandler);
     }
+
     if (this.hasCapability('windowcoverings_state')) {
       this.knxInterface.addKNXEventListener(settings.ga_status, this.KNXEventHandler);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2293,9 +2293,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2332,10 +2333,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"


### PR DESCRIPTION
1. The configuration still do not ask for all group addresses.  I did not find how to change that.
2. The cursor for setting the (tilt) position should start from the bottom to mimic the store position on the window.  using the invert check box is working but not the widget.
3. I added the DPT5.001 as a real percentage

Thanks for taking this PR into consideration to improve window covering. 

I do use this PR in my homey pro and can now handle all my sun blinds as they should (using the 2 cursors only)
