### PR TITLE
Wrap the socket.close in a try-catch

### DIFF
--- a/lib/KNXInterface.js
+++ b/lib/KNXInterface.js
@@ -118,9 +118,26 @@ class KNXInterface extends EventEmitter {
       this.log('IP has not changed, maintaining current connection');
     } else {
       this.log('Creating new KNX tunnel connection');
-      this.knxConnection.Disconnect();
-      // Store the new IP on the this context, then create a new KNXconnection
       this.ipAddress = newIPaddress;
+      this._reconnect();
+    }
+  }
+
+  // Safely disconnect and reconnect the KNX connection
+  _reconnect() {
+    if (!this.knxConnection) {
+      this.isConnected = false;
+      this.createConnection();
+      return;
+    }
+    try {
+      this.knxConnection.Disconnect(() => {
+        this.isConnected = false;
+        this.createConnection();
+      });
+    } catch (error) {
+      this.log('Error during disconnect, forcing reconnect', error);
+      this.isConnected = false;
       this.createConnection();
     }
   }

--- a/lib/KNXInterfaceManager.js
+++ b/lib/KNXInterfaceManager.js
@@ -208,7 +208,11 @@ class KNXInterfaceManager extends EventEmitter {
           .on('error', (err) => {
             // If the udp server errors, close the connection
             console.error('udp server error:', err.stack);
-            udpSocket.close();
+            try {
+              udpSocket.close();
+            } catch (e) {
+              // socket may already be closed
+            }
             this.searchRunning = false;
             reject(err);
           })
@@ -257,7 +261,11 @@ class KNXInterfaceManager extends EventEmitter {
           .bind(36710);
 
         setTimeout(() => {
-          udpSocket.close();
+          try {
+            udpSocket.close();
+          } catch (error) {
+            // socket may already be closed
+          }
           this.searchRunning = false;
           this.log('Closed search UDP socket');
           // Log all the found interfaces
@@ -315,7 +323,11 @@ class KNXInterfaceManager extends EventEmitter {
           .on('error', (err) => {
             // If the udp server errors, close the connection
             console.error('UDP server error', err.stack);
-            udpSocket.close();
+            try {
+              udpSocket.close();
+            } catch (e) {
+              // socket may already be closed
+            }
             this.searchRunning = false;
             reject(err);
           })
@@ -330,7 +342,11 @@ class KNXInterfaceManager extends EventEmitter {
               });
             } else if (commResult.type === 0x209) {
               // console.log('Closing connection');
-              udpSocket.close();
+              try {
+                udpSocket.close();
+              } catch (e) {
+                // socket may already be closed
+              }
             } else if (commResult.type === 0x204) {
               // console.log('Received description response');
               const knxInterface = {
@@ -340,7 +356,11 @@ class KNXInterfaceManager extends EventEmitter {
                 knxAddress: commResult.knxAddress,
               };
 
-              udpSocket.close();
+              try {
+                udpSocket.close();
+              } catch (e) {
+                // socket may already be closed
+              }
               this.interfaceFound = true;
               this.searchRunning = false;
 
@@ -370,9 +390,12 @@ class KNXInterfaceManager extends EventEmitter {
 
         setTimeout(() => {
           if (!this.interfaceFound) {
-            udpSocket.close();
+            try {
+              udpSocket.close();
+            } catch (error) {
+              // socket may already be closed
+            }
             this.searchRunning = false;
-            // this.log('Closed search UDP socket');
             reject(new Error('interface_not_found'));
           }
         }, 5 * 1000); // 5 second timeout


### PR DESCRIPTION
Solves uncaught error:
Error [ERR_SOCKET_DGRAM_NOT_RUNNING]: Not running
    at healthCheck (node:dgram:965:11)
    at Socket.close (node:dgram:790:3)
    at Timeout._onTimeout (/app/lib/KNXInterfaceManager.js:260:21)
    at listOnTimeout (node:internal/timers:585:17)
    at process.processTimers (node:internal/timers:521:7)